### PR TITLE
Save button active on every load

### DIFF
--- a/src/app-utils/gnc-sx-instance-model.c
+++ b/src/app-utils/gnc-sx-instance-model.c
@@ -78,7 +78,7 @@ scrub_sx_split_numeric (Split* split, const char *debcred)
     const char *numeric = is_credit ?
         "sx-credit-numeric" : "sx-debit-numeric";
     char *formval;
-    gnc_numeric numval;
+    gnc_numeric *numval;
     GHashTable *parser_vars = g_hash_table_new (g_str_hash, g_str_equal);
     char *error_loc;
     gnc_numeric amount = gnc_numeric_zero ();
@@ -93,7 +93,7 @@ scrub_sx_split_numeric (Split* split, const char *debcred)
     if (!parse_result || g_hash_table_size (parser_vars) != 0)
         amount = gnc_numeric_zero ();
     g_hash_table_unref (parser_vars);
-    if (gnc_numeric_eq (amount, numval))
+    if (gnc_numeric_eq (amount, *numval))
         return FALSE;
     qof_instance_set (QOF_INSTANCE (split),
 		  numeric, &amount,


### PR DESCRIPTION
The gnc_numeric numval was being set with a valid numeric and hence was always different to the parsed amount.